### PR TITLE
Tokenizer to return sentence_id with span

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='stanfordcorenlp',
     packages=['stanfordcorenlp'],
-    version='3.9.1.1',
+    version='3.9.2.0',
     description='Python wrapper for Stanford CoreNLP.',
 
     author='Lynten Guo',

--- a/stanfordcorenlp/corenlp.py
+++ b/stanfordcorenlp/corenlp.py
@@ -162,14 +162,20 @@ class StanfordCoreNLP:
         r_dict = self._request(semgrex_url, "tokenize,ssplit,depparse", sentence, pattern=pattern)
         return r_dict
 
-    def word_tokenize(self, sentence, span=False):
+    def word_tokenize(self, sentence, span=False, span_and_sentence_id=False):
         r_dict = self._request(self.url, 'ssplit,tokenize', sentence)
         tokens = [token['originalText'] for s in r_dict['sentences'] for token in s['tokens']]
 
         # Whether return token span
-        if span:
-            spans = [(token['characterOffsetBegin'], token['characterOffsetEnd']) for s in r_dict['sentences'] for token
+        spans = None
+        if span or span_and_sentence_id:
+            spans = [(token['characterOffsetBegin'], token['characterOffsetEnd']) for s in
+                     r_dict['sentences'] for token
                      in s['tokens']]
+        if span_and_sentence_id:
+            sentence_ids = [i for i, s in enumerate(r_dict['sentences']) for token in s['tokens']]
+            return tokens, spans, sentence_ids
+        elif span:
             return tokens, spans
         else:
             return tokens


### PR DESCRIPTION
- [x] By default, the sentence structure resulting from the WordsToSentence annotator (https://stanfordnlp.github.io/CoreNLP/ssplit.html) are not returned. I added an option to return a "sentence_id".
- [x] Uploaded new version to s3: https://s3.console.aws.amazon.com/s3/object/google-drive-data/stanfordcorenlp-3.9.2.0-py2.py3-none-any.whl